### PR TITLE
Create Control-Signals.md

### DIFF
--- a/Control-Signals.md
+++ b/Control-Signals.md
@@ -1,0 +1,36 @@
+# List of Control Signals in Linux (Ctrl Key Combinations)
+
+In Linux, several control (Ctrl) key combinations send signals to running processes or affect terminal behavior. These signals help you manage processes and control the terminal effectively. Below is a detailed list of common control signals, their key combinations, and their functions:
+
+| Key Combination | Signal              | Description                                                                                               |
+|-----------------|---------------------|-----------------------------------------------------------------------------------------------------------|
+| **Ctrl + C**    | SIGINT (2)          | Interrupts the process. This sends a signal to terminate or stop the process gracefully.                |
+| **Ctrl + Z**    | SIGTSTP (20)        | Suspends (pauses) the process, placing it in the background. You can later resume it using the `fg` command.|
+| **Ctrl + D**    | EOF (End of File)   | Indicates the end of input. Commonly used in interactive shells to signal that no more input will be given.|
+| **Ctrl + S**    | XOFF                | Freezes terminal output (pauses data flow to the screen). This can help when too much output scrolls by.  |
+| **Ctrl + Q**    | XON                 | Resumes terminal output that was frozen by Ctrl + S.                                                     |
+| **Ctrl + \\**   | SIGQUIT (3)         | Quits the process. This sends a quit signal that, unlike SIGINT, also generates a core dump for debugging.|
+| **Ctrl + L**    | (No signal)         | Clears the terminal screen. Equivalent to executing the `clear` command.                                |
+| **Ctrl + R**    | (No signal)         | Initiates a reverse search of the command history, allowing you to quickly recall previous commands.     |
+
+---
+
+## Additional Information
+
+- **SIGINT (Ctrl + C):**  
+  Used most frequently to stop applications that are running interactively. It is a gentle way of asking a program to terminate, allowing cleanup before exiting.
+
+- **SIGTSTP (Ctrl + Z):**  
+  Instead of killing the process, this signal simply suspends it. Suspended jobs can be resumed in the foreground using `fg` or in the background using `bg`.
+
+- **EOF (Ctrl + D):**  
+  In terminal sessions, this indicates that there is no more data. For example, when using commands like `cat` or entering input in a shell, pressing Ctrl + D signals the end.
+
+- **XOFF and XON (Ctrl + S and Ctrl + Q):**  
+  These are used to control data flow on the terminal. XOFF stops the output from scrolling, which can be helpful if you need to pause the output to examine it, while XON resumes the output.
+
+- **SIGQUIT (Ctrl + \\):**  
+  This signal is similar to SIGINT but is stronger; the process is terminated and a core dump may be generated, which is useful for debugging purposes when a program misbehaves.
+
+- **Clearing and Searching in the Terminal (Ctrl + L and Ctrl + R):**  
+  Ctrl + L provides a quick way to clear the screen without entering a command, while Ctrl + R helps you search backward through your command history, enhancing productivity.


### PR DESCRIPTION
# List of Control Signals in Linux (Ctrl Key Combinations)

In Linux, several control (Ctrl) key combinations send signals to running processes or affect terminal behavior. These signals help you manage processes and control the terminal effectively. Below is a detailed list of common control signals, their key combinations, and their functions:

| Key Combination | Signal              | Description                                                                                               |
|-----------------|---------------------|-----------------------------------------------------------------------------------------------------------|
| **Ctrl + C**    | SIGINT (2)          | Interrupts the process. This sends a signal to terminate or stop the process gracefully.                |
| **Ctrl + Z**    | SIGTSTP (20)        | Suspends (pauses) the process, placing it in the background. You can later resume it using the `fg` command.|
| **Ctrl + D**    | EOF (End of File)   | Indicates the end of input. Commonly used in interactive shells to signal that no more input will be given.|
| **Ctrl + S**    | XOFF                | Freezes terminal output (pauses data flow to the screen). This can help when too much output scrolls by.  |
| **Ctrl + Q**    | XON                 | Resumes terminal output that was frozen by Ctrl + S.                                                     |
| **Ctrl + \\**   | SIGQUIT (3)         | Quits the process. This sends a quit signal that, unlike SIGINT, also generates a core dump for debugging.|
| **Ctrl + L**    | (No signal)         | Clears the terminal screen. Equivalent to executing the `clear` command.                                |
| **Ctrl + R**    | (No signal)         | Initiates a reverse search of the command history, allowing you to quickly recall previous commands.     |

---

## Additional Information

- **SIGINT (Ctrl + C):**   Used most frequently to stop applications that are running interactively. It is a gentle way of asking a program to terminate, allowing cleanup before exiting.

- **SIGTSTP (Ctrl + Z):**   Instead of killing the process, this signal simply suspends it. Suspended jobs can be resumed in the foreground using `fg` or in the background using `bg`.

- **EOF (Ctrl + D):**   In terminal sessions, this indicates that there is no more data. For example, when using commands like `cat` or entering input in a shell, pressing Ctrl + D signals the end.

- **XOFF and XON (Ctrl + S and Ctrl + Q):**   These are used to control data flow on the terminal. XOFF stops the output from scrolling, which can be helpful if you need to pause the output to examine it, while XON resumes the output.

- **SIGQUIT (Ctrl + \\):**   This signal is similar to SIGINT but is stronger; the process is terminated and a core dump may be generated, which is useful for debugging purposes when a program misbehaves.

- **Clearing and Searching in the Terminal (Ctrl + L and Ctrl + R):**   Ctrl + L provides a quick way to clear the screen without entering a command, while Ctrl + R helps you search backward through your command history, enhancing productivity.